### PR TITLE
fix: version string less than 20 characters

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -23,6 +23,10 @@ func Version() string {
 			dirty = true
 		}
 	}
+	print(versionStr)
+
+	// Short SHA. 1Password has a limit of 20 characters for the version.
+	versionStr = versionStr[0:7]
 
 	if dirty {
 		versionStr += "-dirty"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -23,7 +23,6 @@ func Version() string {
 			dirty = true
 		}
 	}
-	print(versionStr)
 
 	// Short SHA. 1Password has a limit of 20 characters for the version.
 	versionStr = versionStr[0:7]


### PR DESCRIPTION
1Password's API supports a maximum of 20 characters in the client-reported version string. Previously, the `version` package used the entire Git SHA (40 characters) when reporting the version. This change uses the first 8 characters of the Git SHA instead to comply with the API constraint.